### PR TITLE
無駄な空白の削除と、タイムゾーンの変更

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,8 +70,9 @@ func retrive(feed config.Feed) ([]gofeed.Item, error) {
 	if err != nil {
 		return []gofeed.Item{}, fmt.Errorf("error: while executing GetRss %s", err)
 	}
-	items := r.Items
-	ret := FilterWithDublinCore(items, time.Now())
+	loc, _ := time.LoadLocation("UTC")
+	now := time.Now().In(loc)
+	ret := FilterWithDublinCore(r.Items, now)
 	return ret, nil
 }
 

--- a/notifier/slack/slack.go
+++ b/notifier/slack/slack.go
@@ -1,6 +1,8 @@
 package slack
 
-import "github.com/nlopes/slack"
+import (
+	"github.com/nlopes/slack"
+)
 
 // PostMessageWithAttachments sends to Slack with attachments
 func (c *Client) PostMessageWithAttachments(attachments []slack.Attachment) error {
@@ -14,7 +16,7 @@ func (c *Client) PostMessageWithAttachments(attachments []slack.Attachment) erro
 
 // Attachments return []slack.Attachment
 func (c *Client) Attachments() []slack.Attachment {
-	attachments := make([]slack.Attachment, 10)
+	var attachments []slack.Attachment
 	for _, item := range c.Config.Item {
 		attachment := slack.Attachment{
 			Title:      item.Title,


### PR DESCRIPTION
* タイムゾーンをUTCに統一した。
    * `time.Now()` は実行環境によりタイムゾーンが異なるため。
* 無駄な空行がSlackに出力されていた問題を修正した